### PR TITLE
Use deepcopy if the instance exists

### DIFF
--- a/drf_model_serializer/serializers.py
+++ b/drf_model_serializer/serializers.py
@@ -1,3 +1,5 @@
+from copy import deepcopy
+
 from django.core.exceptions import ValidationError
 from rest_framework.serializers import ModelSerializer as DRFModelSerializer, as_serializer_error
 
@@ -7,7 +9,7 @@ class ModelSerializer(DRFModelSerializer):
     def validate(self, data):
         # Use existing model instance when it's an update operation or
         # initiate new instance when it's a create operation
-        instance = self.instance if self.instance else self.Meta.model()
+        instance = deepcopy(self.instance) if self.instance else self.Meta.model()
         for key, value in data.items():
             setattr(instance, key, value)
 


### PR DESCRIPTION
## Description
This PR change the way the `validate` method retrieve existing instance. Instead of use `self.instance` we should use `deepcopy(self.instance)` to avoid updating the `self.instance` attributes

This PR closes #5 