### PR TITLE
0.0.2 to master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.0.2] - 2021-08-16
+### Changed
+- Use `deepcopy` instead of directly set up the `self.instance` values in the `validate` method
+
+
 ## [0.0.1] - 2019-11-21
 ### Added
 - Introduce `drf-model-serializer` library

--- a/drf_model_serializer/serializers.py
+++ b/drf_model_serializer/serializers.py
@@ -1,3 +1,5 @@
+from copy import deepcopy
+
 from django.core.exceptions import ValidationError
 from rest_framework.serializers import ModelSerializer as DRFModelSerializer, as_serializer_error
 
@@ -7,7 +9,7 @@ class ModelSerializer(DRFModelSerializer):
     def validate(self, data):
         # Use existing model instance when it's an update operation or
         # initiate new instance when it's a create operation
-        instance = self.instance if self.instance else self.Meta.model()
+        instance = deepcopy(self.instance) if self.instance else self.Meta.model()
         for key, value in data.items():
             setattr(instance, key, value)
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="drf-model-serializer",
-    version="0.0.1",
+    version="0.0.2",
     author="Panji Y. Wiwaha",
     author_email="panjiyudasetya@gmail.com",
     description="A simple library that enhance 'ModelSerializer' class so that it performs object-level validation for free.",


### PR DESCRIPTION
## [0.0.2] - 2021-08-16
### Changed
- Use `deepcopy` instead of directly set up the `self.instance` values in the `validate` method