### PR TITLE
0.0.2 to develop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.0.2] - 2021-08-16
+### Changed
+- Use `deepcopy` instead of directly set up the `self.instance` values in the `validate` method
+
+
 ## [0.0.1] - 2019-11-21
 ### Added
 - Introduce `drf-model-serializer` library

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="drf-model-serializer",
-    version="0.0.1",
+    version="0.0.2",
     author="Panji Y. Wiwaha",
     author_email="panjiyudasetya@gmail.com",
     description="A simple library that enhance 'ModelSerializer' class so that it performs object-level validation for free.",


### PR DESCRIPTION
## [0.0.2] - 2021-08-16
### Changed
- Use `deepcopy` instead of directly set up the `self.instance` values in the `validate` method